### PR TITLE
Fix script for filtering of SPAdes contigs by length and coverage

### DIFF
--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -9,12 +9,12 @@ def size_input():
     """Sets size cut-off and check for valid user input."""
     global size
     while True:
-        size = raw_input('Enter size cut-off for SPAdes output (Press enter for 500 bp default): ')
+        size = input('Enter size cut-off for SPAdes output (Press enter for 500 bp default): ')
         if size == '':
             size = 500
             break
         elif not size.isdigit():
-            print 'Invalid input. Please try again'
+            print('Invalid input. Please try again')
             continue
         else:
             break 
@@ -23,12 +23,12 @@ def cov_input():
     """Sets coverage cut-off and check for valid user input."""
     global cov
     while True:
-        cov = raw_input('Enter coverage cut-off for blast output (Press enter for 10 times default): ')
+        cov = input('Enter coverage cut-off for blast output (Press enter for 10 times default): ')
         if cov == '':
             cov = 10
             break
         elif not cov.isdigit():  
-            print 'Invalid input. Please try again'
+            print('Invalid input. Please try again')
             continue
         else:
             break 
@@ -37,15 +37,15 @@ def assemble_type():
     """Asks user what settings they would like to use for SPAdes assembly"""
     global assemble_choice, final_choice
     while True:
-        print '\nWhat type of SPAdes assembly would you like to run?\n'
-        print '   1) SPAdes w/ error correct and assemble'
-        print '   2) SPAdes careful w/ error correct and assemble'
-        print '   3) metaSPAdes w/ error correct and assemble'
-        print '   4) SPAdes w/ assemble only'
-        print '   5) SPAdes careful w/ assemble only'
-        print '   6) metaSPAdes w/ assemble only'
-        print '   7) Custom input (manually enter options)\n'
-        assemble_choice = raw_input('Enter the number for your selection: ')
+        print('\nWhat type of SPAdes assembly would you like to run?\n')
+        print('   1) SPAdes w/ error correct and assemble')
+        print('   2) SPAdes careful w/ error correct and assemble')
+        print('   3) metaSPAdes w/ error correct and assemble')
+        print('   4) SPAdes w/ assemble only')
+        print('   5) SPAdes careful w/ assemble only')
+        print('   6) metaSPAdes w/ assemble only')
+        print('   7) Custom input (manually enter options)\n')
+        assemble_choice = input('Enter the number for your selection: ')
         if assemble_choice == '1':
             final_choice = 'SPAdes w/ error correction and assembly'
             break
@@ -65,12 +65,12 @@ def assemble_type():
             final_choice = 'metaSPAdes w/ assemble only'
             break
         elif assemble_choice == '7': 
-            print '\nEnter modifiers/parameters as you would enter then into a manual SPAdes run (eg. --meta).'
-            print 'Do not enter input file name(s) and output folder name as they will be automatically selected.'
-            final_choice = raw_input('Enter custom options: ')
+            print('\nEnter modifiers/parameters as you would enter then into a manual SPAdes run (eg. --meta).')
+            print('Do not enter input file name(s) and output folder name as they will be automatically selected.')
+            final_choice = input('Enter custom options: ')
             break
         else:
-            print 'Invalid input. Please try again'
+            print('Invalid input. Please try again')
             continue
 
 def parameter_input():
@@ -79,28 +79,29 @@ def parameter_input():
         size_input()
         cov_input()
         assemble_type()
-        print '\n***CURRENT SETTINGS***\n   - Size cut-off:', size, 'bp\n   - Coverage cut-off:', cov, 'times\n   - Assembly type:', final_choice
-        begin = raw_input('\nContinue (Y/N)? ').lower()
+        print('\n***CURRENT SETTINGS***\n   - Size cut-off:', size, 'bp\n   - Coverage cut-off:', cov, 'times\n   - Assembly type:', final_choice)
+        begin = input('\nContinue (Y/N)? ').lower()
         if begin[0] == 'y':
             break
         else:
-            print 'Please try again. \n'
+            print('Please try again. \n')
             continue
 
 def size_filter():
     """ Filters SPAdes output by size"""
-    contigs = [rec for rec in SeqIO.parse(fasta, 'fasta')]
-    filter_by_size = [c for c in contigs if float(c.name.split('_')[3] >= float(size_input())
-        continue
+    contigs = [rec for rec in SeqIO.parse('contigs.fasta', 'fasta')]
+    filter_by_size = [c for c in contigs if float(c.name.split('_')[3]) >= float(size_input())]
+
+    return filter_by_size
 
 def coverage_filter():
     """ Filters SPAdes output by coverage"""
 
     contigs = size_filter()
 
-    filter_by_cov = [c for c in contigs if float(c.name.split('_')[5] >= float(cov_input)
+    filter_by_cov = [c for c in contigs if float(c.name.split('_')[5]) >= float(cov_input)]
 
-        continue
+    return filter_by_cov
 
 def pipeline():
     """Finds each set of paired reads and assigns them to variable R1 and R2.

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -2,7 +2,6 @@
 
 import subprocess
 import glob
-import os
 from Bio import SeqIO
 from collections import defaultdict
 import re

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -2,8 +2,7 @@
 
 import subprocess
 import glob
-#import string
-# No need to import string module in recent versions of Python
+from Bio import SeqIO
 import re
 
 def size_input():
@@ -88,21 +87,20 @@ def parameter_input():
             print 'Please try again. \n'
             continue
 
-def fasta_to_tab():
-    """Converts fasta output from SPAdes into tab format for easier filtering"""
-    with open(out + '/' + 'contigs.fasta', 'r') as f, open(out + '/' + 'contigs.tab', 'w') as file_out:
-        for line in f:
-            line = line.strip()
-            if line[0] == '>':
-                 file_out.write('{}\t'.format(line))
-            else:
-                 file_out.write('{}\n'.format(line))
-
 def size_filter():
+    """ Filters SPAdes output by size"""
+    contigs = [rec for rec in SeqIO.parse(fasta, 'fasta')]
+    filter_by_size = [c for c in contigs if float(c.name.split('_')[3] >= float(size_input())
+        continue
 
-def pre_blast_filter():
-    fasta_to_tab()
-    subprocess.call([])
+def coverage_filter():
+    """ Filters SPAdes output by coverage"""
+
+    contigs = size_filter()
+
+    filter_by_cov = [c for c in contigs if float(c.name.split('_')[5] >= float(cov_input)
+
+        continue
 
 def pipeline():
     """Finds each set of paired reads and assigns them to variable R1 and R2.

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -137,5 +137,4 @@ def pipeline():
 
 parameter_input()
 pipeline()
-size_filter()
-coverage_filter()
+size_and_cov_filter()

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -94,7 +94,7 @@ def size_and_cov_filter():
 
     contig_dict = defaultdict(list)
 
-    for fasta in glob.glob('*/*/contigs.fasta'):
+    for fasta in glob.glob('*/contigs.fasta'):
         
         contig_dict[fasta] = [rec for rec in SeqIO.parse(fasta, 'fasta')]
         

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -1,4 +1,10 @@
-import subprocess, glob, string, re
+#!/usr/bin env python3
+
+import subprocess
+import glob
+#import string
+# No need to import string module in recent versions of Python
+import re
 
 def size_input():
     """Sets size cut-off and check for valid user input."""
@@ -105,7 +111,7 @@ def pipeline():
     for file in glob.glob('*_R1_*fastq*'):
         global R1, R2, out
         R1 = file
-        R2 = string.replace(R1, '_R1_', '_R2_')
+        R2 = str.replace(R1, '_R1_', '_R2_')
         out = re.sub(r'.fastq.*', '', R1) + '_SpadesOutput'
         if assemble_choice == '1':                              
             subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out])

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -99,16 +99,16 @@ def size_and_cov_filter():
         contig_dict[fasta] = [rec for rec in SeqIO.parse(fasta, 'fasta')]
         
         for keys,values in cov_dir.iteritems():
-        contig_dict[keys] = [v for v in values if 
-                float(v.name.split('_')[3]) >= float(size_input()) and 
-                float(v.name.split('_')[5]) >= float(cov_input())
-                ]
-
-        filtered_filename = str.replace(k,".fasta","")
-
-        new_extension = "filtered.fasta"
-
-        SeqIO.write(v, os.path.join(filtered_filename + new_extension), 'fasta')
+            contig_dict[keys] = [v for v in values if 
+                    float(v.name.split('_')[3]) >= float(size_input()) and 
+                    float(v.name.split('_')[5]) >= float(cov_input())
+                    ]
+            
+            filtered_filename = str.replace(k,".fasta","")
+            
+            new_extension = "filtered.fasta"
+            
+            SeqIO.write(v, os.path.join(filtered_filename + new_extension), 'fasta')
 
 def pipeline():
     """Finds each set of paired reads and assigns them to variable R1 and R2.

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -2,7 +2,9 @@
 
 import subprocess
 import glob
+import os
 from Bio import SeqIO
+from collections import defaultdict
 import re
 
 def size_input():
@@ -87,21 +89,26 @@ def parameter_input():
             print('Please try again. \n')
             continue
 
-def size_filter():
-    """ Filters SPAdes output by size"""
-    contigs = [rec for rec in SeqIO.parse('contigs.fasta', 'fasta')]
-    filter_by_size = [c for c in contigs if float(c.name.split('_')[3]) >= float(size_input())]
+def size_and_cov_filter():
+    """ Filters SPAdes output by size and coverage """
 
-    return filter_by_size
+    contig_dict = defaultdict(list)
 
-def coverage_filter():
-    """ Filters SPAdes output by coverage"""
+    for fasta in glob.glob('*/*/contigs.fasta'):
+        
+        contig_dict[fasta] = [rec for rec in SeqIO.parse(fasta, 'fasta')]
+        
+        for keys,values in cov_dir.iteritems():
+        contig_dict[keys] = [v for v in values if 
+                float(v.name.split('_')[3]) >= float(size_input()) and 
+                float(v.name.split('_')[5]) >= float(cov_input())
+                ]
 
-    contigs = size_filter()
+        filtered_filename = str.replace(k,".fasta","")
 
-    filter_by_cov = [c for c in contigs if float(c.name.split('_')[5]) >= float(cov_input)]
+        new_extension = "filtered.fasta"
 
-    return filter_by_cov
+        SeqIO.write(v, os.path.join(filtered_filename + new_extension), 'fasta')
 
 def pipeline():
     """Finds each set of paired reads and assigns them to variable R1 and R2.
@@ -113,20 +120,22 @@ def pipeline():
         R2 = str.replace(R1, '_R1_', '_R2_')
         out = re.sub(r'.fastq.*', '', R1) + '_SpadesOutput'
         if assemble_choice == '1':                              
-            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out])
+            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out])
         elif assemble_choice == '2':
-            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--careful'])
+            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--careful'])
         elif assemble_choice == '3':
-            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--meta'])
+            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--meta'])
         elif assemble_choice == '4':                                                                                                                                            
-            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--only-assembler'])                                                                       
+            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--only-assembler'])                                                                       
         elif assemble_choice == '5':
-            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--careful', '--only-assembler'])
+            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--careful', '--only-assembler'])
         elif assemble_choice == '6':
-            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--meta', '--only-assembler'])
+            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--meta', '--only-assembler'])
         elif assemble_choice == '7':
-            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, final_choice])
+            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, final_choice])
         #pre_blast_filter()
 
 parameter_input()
 pipeline()
+size_filter()
+coverage_filter()

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -1,4 +1,4 @@
-#!/usr/bin env python3
+#!/usr/bin/env python3
 
 import subprocess
 import glob

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -33,7 +33,7 @@ def cov_input():
             print('Invalid input. Please try again')
             continue
         else:
-            break 
+            break
 
 def assemble_type():
     """Asks user what settings they would like to use for SPAdes assembly"""
@@ -98,17 +98,15 @@ def size_and_cov_filter():
         
         contig_dict[fasta] = [rec for rec in SeqIO.parse(fasta, 'fasta')]
         
-        for keys,values in cov_dir.iteritems():
-            contig_dict[keys] = [v for v in values if 
-                    float(v.name.split('_')[3]) >= float(size_input()) and 
-                    float(v.name.split('_')[5]) >= float(cov_input())
-                    ]
+    for keys,values in contig_dict.items():
+
+        contig_dict[keys] = [v for v in values 
+        if float(v.name.split('_')[5]) >= float(cov) 
+        and float(v.name.split('_')[3]) >= float(size)]
             
-            filtered_filename = str.replace(k,".fasta","")
+        filtered_filename = str.replace(keys,".fasta","_filtered.fasta")
             
-            new_extension = "filtered.fasta"
-            
-            SeqIO.write(v, os.path.join(filtered_filename + new_extension), 'fasta')
+        SeqIO.write(values, filtered_filename, 'fasta')
 
 def pipeline():
     """Finds each set of paired reads and assigns them to variable R1 and R2.
@@ -120,19 +118,19 @@ def pipeline():
         R2 = str.replace(R1, '_R1_', '_R2_')
         out = re.sub(r'.fastq.*', '', R1) + '_SpadesOutput'
         if assemble_choice == '1':                              
-            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out])
+            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out])
         elif assemble_choice == '2':
-            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--careful'])
+            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--careful'])
         elif assemble_choice == '3':
-            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--meta'])
+            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--meta'])
         elif assemble_choice == '4':                                                                                                                                            
-            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--only-assembler'])                                                                       
+            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--only-assembler'])                                                                       
         elif assemble_choice == '5':
-            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--careful', '--only-assembler'])
+            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--careful', '--only-assembler'])
         elif assemble_choice == '6':
-            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, '--meta', '--only-assembler'])
+            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, '--meta', '--only-assembler'])
         elif assemble_choice == '7':
-            subprocess.call(['spades.py', '-1', R1, '-2', R2, '-o', out, final_choice])
+            subprocess.call(['echo', 'spades.py', '-1', R1, '-2', R2, '-o', out, final_choice])
         #pre_blast_filter()
 
 parameter_input()

--- a/SPAdesBatch.py
+++ b/SPAdesBatch.py
@@ -12,8 +12,9 @@ def size_input():
     global size
     while True:
         size = input('Enter size cut-off for SPAdes output (Press enter for 500 bp default): ')
-        if size == '':
-            size = 500
+        default_size = 500
+        if not size:
+            size = default_size
             break
         elif not size.isdigit():
             print('Invalid input. Please try again')
@@ -25,9 +26,10 @@ def cov_input():
     """Sets coverage cut-off and check for valid user input."""
     global cov
     while True:
-        cov = input('Enter coverage cut-off for blast output (Press enter for 10 times default): ')
-        if cov == '':
-            cov = 10
+        cov = input('Enter coverage cut-off for SPAdes output (Press enter for 10 times default): ')
+        default_cov = 10
+        if not cov:
+            cov = default_cov
             break
         elif not cov.isdigit():  
             print('Invalid input. Please try again')
@@ -93,19 +95,19 @@ def size_and_cov_filter():
     """ Filters SPAdes output by size and coverage """
 
     contig_dict = defaultdict(list)
-
+        
     for fasta in glob.glob('*/contigs.fasta'):
-        
+            
         contig_dict[fasta] = [rec for rec in SeqIO.parse(fasta, 'fasta')]
-        
+            
     for keys,values in contig_dict.items():
+            
+        contig_dict[keys] = [v for v in values if float(v.name.split('_')[5]) >= float(cov) and float(v.name.split('_')[3]) >= float(size)]
 
-        contig_dict[keys] = [v for v in values 
-        if float(v.name.split('_')[5]) >= float(cov) 
-        and float(v.name.split('_')[3]) >= float(size)]
-            
+    for keys,values in contig_dict.items():
+        
         filtered_filename = str.replace(keys,".fasta","_filtered.fasta")
-            
+        
         SeqIO.write(values, filtered_filename, 'fasta')
 
 def pipeline():


### PR DESCRIPTION
* Adapted code to Python3
* Modified list of modules: added BioPython and collections, and removed unnecessary modules (e.g. string)
* Modified handling of default values for filtering
* Created a new function for filtering contigs based on length __and__ coverage
* The output of said function is a FASTA file with the filtered contigs
* Code has been tested with `echo` before SPAdes, and also running assembly with real data using SPAdes (option #4)